### PR TITLE
Improve compatibility for the `FindZLIB` module

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,6 +60,7 @@ jobs:
           -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED=NO
           -DCPM_SOURCE_CACHE="${{ env.cpm-path }}"
           -DZLIB_SANITIZE=${{ matrix.sanitize }}
+          -DZLIB_VERBOSE=ON
 
       - name: Build
         run: cmake --build --preset ${{ matrix.preset }} --config ${{ matrix.config }}
@@ -99,6 +100,7 @@ jobs:
         run: >
           cmake --preset ${{ matrix.preset }}
           -DCPM_SOURCE_CACHE=${{ env.cpm-path }}
+          -DZLIB_VERBOSE=ON
 
       - name: Build
         run: cmake --build --preset ${{ matrix.preset }} --config ${{ matrix.config }}
@@ -146,7 +148,8 @@ jobs:
               -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install \
               -DCPM_SOURCE_CACHE=${{ env.cpm-path }}                 \
               -DZLIB_INSTALL=ON                                      \
-              -DZLIB_TEST=ON
+              -DZLIB_TEST=ON                                         \
+              -DZLIB_VERBOSE=ON
             cmake --build build
             cd build
             ctest -V -C ${{ matrix.config }}
@@ -188,6 +191,7 @@ jobs:
           -DCPM_SOURCE_CACHE=${{ env.cpm-path }}
           -DZLIB_INSTALL=ON
           -DZLIB_TEST=ON
+          -DZLIB_VERBOSE=ON
 
       - name: Build
         run: cmake --build build
@@ -223,6 +227,7 @@ jobs:
           -DCPM_SOURCE_CACHE=${{ env.cpm-path }}
           -DZLIB_INSTALL=ON
           -DZLIB_TEST=ON
+          -DZLIB_VERBOSE=ON
 
       - name: Build
         run: cmake --build build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ include(cmake/UseSanitizer.cmake)
 # Custom options
 option(ZLIB_INSTALL "Install zlib and CMake targets" OFF)
 option(ZLIB_TEST "Enable testing and build tests" OFF)
+option(ZLIB_VERBOSE "Print result variables of FindZLIB module" OFF)
 
 if(DEFINED ZLIB_USE_STATIC_LIBS)
     if(ZLIB_USE_STATIC_LIBS AND BUILD_SHARED_LIBS)
@@ -53,6 +54,13 @@ set(ZLIB_INCLUDE_DIRS ${zlib_SOURCE_DIR} ${zlib_BINARY_DIR} CACHE STRING "Overri
 set(ZLIB_LIBRARIES "$<TARGET_LINKER_FILE:ZLIB::ZLIB>" CACHE STRING "Override FindZLIB variables" FORCE)
 set(ZLIB_FOUND ON CACHE BOOL "Override FindZLIB variables" FORCE)
 set(ZLIB_VERSION ${PROJECT_VERSION} CACHE STRING "Override FindZLIB variables" FORCE)
+
+if(ZLIB_VERBOSE)
+    message(STATUS "ZLIB_INCLUDE_DIRS : ${ZLIB_INCLUDE_DIRS}")
+    message(STATUS "ZLIB_LIBRARIES    : ${ZLIB_LIBRARIES}")
+    message(STATUS "ZLIB_FOUND        : ${ZLIB_FOUND}")
+    message(STATUS "ZLIB_VERSION      : ${ZLIB_VERSION}")
+endif()
 
 # Legacy variables of FindZLIB module
 set(ZLIB_VERSION_STRING ${ZLIB_VERSION} CACHE STRING "Override FindZLIB variables" FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ FetchContent_MakeAvailable(ZLIB)
 
 # Result variables of FindZLIB module
 set(ZLIB_INCLUDE_DIRS ${zlib_SOURCE_DIR} ${zlib_BINARY_DIR} CACHE STRING "Override FindZLIB variables" FORCE)
-set(ZLIB_LIBRARIES "" CACHE STRING "Override FindZLIB variables" FORCE)
+set(ZLIB_LIBRARIES "$<TARGET_LINKER_FILE:ZLIB::ZLIB>" CACHE STRING "Override FindZLIB variables" FORCE)
 set(ZLIB_FOUND ON CACHE BOOL "Override FindZLIB variables" FORCE)
 set(ZLIB_VERSION ${PROJECT_VERSION} CACHE STRING "Override FindZLIB variables" FORCE)
 


### PR DESCRIPTION
In some CMake projects, `ZLIB_LIBRARIES` is used in `target_link_libraries()` instead of `ZLIB::ZLIB` target.